### PR TITLE
feat: enable nested language parsing for CSS and JS

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -8,6 +8,7 @@
       "scope": "source.shopware_twig",
       "file-types": ["shopware_twig"],
       "injection-regex": "^shopware_twig$",
+      "injections": "queries/injections.scm",
       "class-name": "TreeSitterShopwareTwig"
     }
   ],


### PR DESCRIPTION
Add injections field to tree-sitter.json to register the injections.scm query file. This enables automatic language injection for CSS content inside <style> tags and JavaScript content inside <script> tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables nested language parsing by wiring the injections query into the grammar configuration.
> 
> - Adds `"injections": "queries/injections.scm"` to `tree-sitter.json` so CSS/JS are auto-injected within style/script blocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e68c98a87a16e0095aec435da1b4f9557616d210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->